### PR TITLE
fix minor grammatical errors on the assignment page

### DIFF
--- a/assignments/wc209/index.html
+++ b/assignments/wc209/index.html
@@ -35,9 +35,9 @@
 
 <h2 class="ui dividing header">Purpose</h2>
 
-<p>(Test text) The purpose of this assignment is to help you learn or review (1)
+<p>The purpose of this assignment is to help you learn or review (1)
 the fundamentals of the C programming language, (2) a portion of the
-"de-commenting" task of the C preprocessor, and (3) how to use the
+"de-commenting" task of the C preprocessor, and (3) use of the
 GNU/Unix programming tools,
 especially <code>bash</code>, <code>vscode</code> (or any editor of your choice),
 and <code>gcc209</code>.</p>
@@ -118,11 +118,11 @@ character constant (<code>'...'</code>).</li>
 <h2 class="ui dividing header" >Functionality</h2>
 
 <p>Your program should read characters from the standard input stream,
-and writes the output to the standard output stream and possibly to
+and write the output to the standard output stream and possibly to
 the standard error stream. Specifically, your program should (1) read
-text from the standard input stream, (2) writes the number of
+text from the standard input stream, (2) write the number of
 newlines, words, and characters in the input text to the standard output
-stream with block and line comment replaced by a space and an empty string respectively, and (3) writes error and
+stream with block and line comment replaced by a space and an empty string respectively, and (3) write error and
 warning messages as appropriate to the standard error stream. A
 typical execution of your program from a shell might look like
 this:</p>
@@ -256,7 +256,7 @@ space. Examples:</p>
 </div>
 
 
-<p>Your program should define "comment" as in the C99 standard. In
+<p>Your program should define a "comment" as in the C99 standard. In
 particular, your program also should consider line comment
 of the form (<code>//...</code>).
 Example:</p>
@@ -306,7 +306,7 @@ Example:</p>
 is, your program should allow a comment to contain newline
 characters. Your program should add blank lines as necessary to
 preserve the original line numbering. Also, each newline character in
-comment is counted as one character. Examples:</p>
+a comment is counted as one character. Examples:</p>
 
 
 <div class="scroll-x-container">


### PR DESCRIPTION
Fixing some small grammatical stuff :)

+ In addition, there is a campuswire post which claims that the tar.gz file in the page does not include the samplewc209 file. I think this should be checked.